### PR TITLE
create comment action for alert without using update alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This table lists the API permissions required for each action. For most use case
 | `update incident` | `SecurityIncident.ReadWrite.All` | `SecurityIncident.ReadWrite.All` |
 | `get alert` | `SecurityAlert.Read.All` | `SecurityAlert.Read.All` |
 | `update alert` | `SecurityAlert.ReadWrite.All` | `SecurityAlert.ReadWrite.All` |
+| `create comment` | `SecurityAlert.ReadWrite.All` | `SecurityAlert.ReadWrite.All` |
 
 ### Authentication Method
 
@@ -287,7 +288,8 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 [get incident](#action-get-incident) - Retrieve specific incident by its ID <br>
 [update incident](#action-update-incident) - Update the properties of an incident object <br>
 [get alert](#action-get-alert) - Retrieve specific alert by its ID <br>
-[update alert](#action-update-alert) - Update properties of existing alert
+[update alert](#action-update-alert) - Update properties of existing alert <br>
+[create comment](#action-create-comment) - Create a comment for an alert
 
 ## action: 'test connectivity'
 
@@ -834,6 +836,31 @@ action_result.data.\*.evidence.\*.vmMetadata.vmId | string | | e3d18363-806f-4d1
 action_result.data.\*.evidence.\*.vmMetadata.resourceId | string | | /subscriptions/test906-0000-test-test-test9test70/resourceGroups/PLUGINFRAMEWORK/providers/test.Compute/virtualMachines/TEST-ID |
 action_result.data.\*.evidence.\*.vmMetadata.cloudProvider | string | | azure |
 action_result.data.\*.evidence.\*.vmMetadata.subscriptionId | string | | |
+
+## action: 'create comment'
+
+Create a comment for an alert
+
+Type: **generic** <br>
+Read only: **False**
+
+#### Action Parameters
+
+PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
+--------- | -------- | ----------- | ---- | --------
+**alert_id** | required | ID of the alert | string | `defender alert id` |
+**comment** | required | The comment to be added to the alert | string | |
+
+#### Action Output
+
+DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
+--------- | ---- | -------- | --------------
+action_result.status | string | | success failed |
+action_result.parameter.alert_id | string | `defender alert id` | xx637812122456454120\_-11082172xx |
+action_result.parameter.comment | string | | Test comment |
+action_result.message | string | | Comment added successfully |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
 
 ## action: 'update alert'
 

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -88,6 +88,7 @@ This table lists the API permissions required for each action. For most use case
 | `update incident` | `SecurityIncident.ReadWrite.All` | `SecurityIncident.ReadWrite.All` |
 | `get alert` | `SecurityAlert.Read.All` | `SecurityAlert.Read.All` |
 | `update alert` | `SecurityAlert.ReadWrite.All` | `SecurityAlert.ReadWrite.All` |
+| `create comment` | `SecurityAlert.ReadWrite.All` | `SecurityAlert.ReadWrite.All` |
 
 ### Authentication Method
 

--- a/microsoft365defender.json
+++ b/microsoft365defender.json
@@ -253,6 +253,75 @@
             "versions": "EQ(*)"
         },
         {
+            "action": "create comment",
+            "identifier": "create_comment",
+            "description": "Create a comment for an alert",
+            "type": "generic",
+            "read_only": false,
+            "parameters": {
+                "alert_id":{
+                    "description": "The ID of the alert",
+                    "data_type" : "string",
+                    "required": true,
+                    "primary": true,
+                    "contains": [],
+                    "value_list": [],
+                    "order": 0,
+                    "default": null,
+                    "name": "alert_id"
+                },
+                "comment": {
+                    "description": "The comment to be added to the alert",
+                    "data_type": "string",
+                    "required": true,
+                    "primary": false,
+                    "contains": [],
+                    "value_list": [],
+                    "order": 1,
+                    "default": null,
+                    "name": "comment"
+                }
+            },
+            "output": [
+                {
+                    "data_path": "action_result.parameter.alert_id",
+                    "data_type": "string",
+                    "contains": [],
+                    "column_name": "alert_id",
+                    "column_order": 0
+                },
+                {
+                    "data_path": "action_result.parameter.comment",
+                    "data_type": "string",
+                    "contains": [],
+                    "column_name": "comment",
+                    "column_order": 1
+                },
+                {
+                    "data_path": "action_result.parameter.status",
+                    "data_type": "string",
+                    "column_name": "status",
+                    "column_order": 2
+                },
+                {
+                    "data_path": "action_result.message",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "summary.total_objects",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "summary.total_objects_successful",
+                    "data_type": "numeric"
+                }
+            ],
+            "render": {
+                "type": "table"
+            },
+            "versions": "EQ(*)"
+        },
+        {
             "action": "list incidents",
             "description": "List all the incidents",
             "type": "investigate",

--- a/microsoft365defender_connector.py
+++ b/microsoft365defender_connector.py
@@ -1412,6 +1412,30 @@ class Microsoft365Defender_Connector(BaseConnector):
             "data": incident,
             "cef": incident,
         }
+    
+    def _handle_create_comment(self, param):
+
+        self.save_progress(f"In action handler for: {self.get_action_identifier()}")
+        action_result = self.add_action_result(ActionResult(dict(param)))
+        alert_id = param[DEFENDER_ALERT_ID]
+
+        request_body = {}
+        request_body["@odata_type"] = DEFENDER_ODATA_TYPE_COMMENT
+        request_body["comment"] = param.get('comment', '')
+
+        endpoint = f"{DEFENDER_MSGRAPH_API_BASE_URL}{DEFENDER_COMMENT_ALERT_ID_ENDPOINT.format(input=alert_id)}"
+    
+        # make rest call
+        ret_val, response = self._update_request(endpoint=endpoint, action_result=action_result, method="post", data=json.dumps(request_body))
+
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+
+        odata_fixed_response = self._fix_up_odata_fields(response)
+
+        action_result.add_data(odata_fixed_response)
+
+        return action_result.set_status(phantom.APP_SUCCESS, DEFENDER_COMMENT_ADDED_SUCCESSFULLY)
 
     def handle_action(self, param):
         ret_val = phantom.APP_SUCCESS
@@ -1439,6 +1463,8 @@ class Microsoft365Defender_Connector(BaseConnector):
             ret_val = self._handle_update_incident(param)
         elif action_id == "on_poll":
             ret_val = self._handle_on_poll(param)
+        elif action_id == "create_comment":
+            ret_val = self._handle_create_comment(param)
 
         return ret_val
 

--- a/microsoft365defender_consts.py
+++ b/microsoft365defender_consts.py
@@ -215,6 +215,11 @@ DEFENDER_INCIDENT_KEYS_MAPPING = {"assign_to": "assignedTo"}
 
 DEFENDER_INVALID_INCIDENT_INPUT = "Please provide a valid value in the '{0}' parameter"
 
+# For create_comment:
+DEFENDER_ODATA_TYPE_COMMENT = "#microsoft.graph.security.alertComment"
+DEFENDER_COMMENT_ALERT_ID_ENDPOINT = "/security/alerts_v2/{input}/comments"
+DEFENDER_COMMENT_ADDED_SUCCESSFULLY = "Successfully added the comment to the alert"
+
 # For on_poll action:
 DEFENDER_APP_DT_STR_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 DEFENDER_CONFIG_START_TIME_SCHEDULED_POLL = "start_time"


### PR DESCRIPTION
### Features
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

- Added new **create comment** action to add comments to alerts in Microsoft 365 Defender
  - Requires only `alert_id` and `comment` as input parameters
  - Provides a lightweight alternative to the `update alert` action which requires additional input values
  - Uses the Microsoft Graph API SecurityAlert endpoint

- [x] I have verified that manual documentation has been updated where appropriate